### PR TITLE
Add curl retries to downloading release info and artifacts

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -91,12 +91,11 @@ runs:
           | .[0].browser_download_url
           '
         )"
-        archive='${{ github.workspace }}\cargo-about-bin\cargo-about.tar.gz'
-        extract_to='${{ github.workspace }}\cargo-about-bin'
-        mkdir "$extract_to"
-        curl --silent --show-error --retry 5 --fail --location "$release_url" > "$archive"
-        tar xvzf "$archive" -C "$extract_to" --strip-components=1
-        echo "$extract_to" >> $GITHUB_PATH
+        mkdir '${{ github.workspace }}\cargo-about-bin'
+        curl --silent --show-error --retry 5 --fail --location "$release_url" > '${{ github.workspace }}\cargo-about-bin\cargo-about.tar.gz'
+        cd '${{ github.workspace }}\cargo-about-bin'
+        tar xvzf 'cargo-about.tar.gz' -C '.' --strip-components=1
+        echo '${{ github.workspace }}\cargo-about-bin' >> $GITHUB_PATH
 
     - name: Generate THIRDPARTY
       shell: bash

--- a/action.yaml
+++ b/action.yaml
@@ -30,40 +30,73 @@ runs:
         bundler-cache: true
         working-directory: ${{ github.action_path }}
 
-    - name: Install cargo-about
+    - name: Install cargo-about for Linux
       shell: bash
+      if: runner.os == 'Linux'
       run: |
-        tarball_test=""
-        if [[ "${{ runner.os }}" == "Linux" ]]; then
-          tarball_test=".*x86_64-unknown-linux.*tar.gz$"
-        elif [[ "${{ runner.os }}" == "macOS" ]]; then
-          tarball_test=".*x86_64-apple-darwin.*tar.gz$"
-        elif [[ "${{ runner.os }}" == "Windows" ]]; then
-          tarball_test=".*x86_64-pc-windows-msvc.*tar.gz$"
-        fi
-        release_api_endpoint="https://api.github.com/repos/EmbarkStudios/cargo-about/releases"
-        release_url="$(curl -s -H "Accept: application/vnd.github.v3+json" "$release_api_endpoint" | jq -r '
+        release_info="$(curl \
+          --silent \
+          --show-error \
+          --retry 5 \
+          --fail \
+          --header "Accept: application/vnd.github.v3+json" \
+          "https://api.github.com/repos/EmbarkStudios/cargo-about/releases"
+        )"
+        release_url="$(echo "$release_info" | jq -r '
           .[0].assets
           | map(select(.browser_download_url
-          | test("'"${tarball_test}"'")))
+          | test(".*x86_64-unknown-linux.*tar.gz$")))
           | .[0].browser_download_url
           '
         )"
-        if [[ "${{ runner.os }}" == "Linux" ]]; then
-          mkdir "${{ github.workspace }}/cargo-about-bin"
-          curl -sL "$release_url" | tar xvz -C "${{ github.workspace }}/cargo-about-bin/" --strip-components=1
-          echo "${{ github.workspace }}/cargo-about-bin" >> $GITHUB_PATH
-        elif [[ "${{ runner.os }}" == "macOS" ]]; then
-          mkdir "${{ github.workspace }}/cargo-about-bin"
-          curl -sL "$release_url" | gtar xvz -C "${{ github.workspace }}/cargo-about-bin/" --strip-components=1
-          echo "${{ github.workspace }}/cargo-about-bin" >> $GITHUB_PATH
-        elif [[ "${{ runner.os }}" == "Windows" ]]; then
-          mkdir '${{ github.workspace }}/cargo-about-bin'
-          curl -sL "$release_url" > '${{ github.workspace }}/cargo-about-bin/cargo-about.tar.gz'
-          cd '${{ github.workspace }}/cargo-about-bin'
-          tar xvzf 'cargo-about.tar.gz' -C '.' --strip-components=1
-          echo '${{ github.workspace }}/cargo-about-bin' >> $GITHUB_PATH
-        fi
+        curl --silent --show-error --retry 5 --fail --location "$release_url" | tar xvz -C /usr/local/bin/ --strip-components=1
+
+    - name: Install cargo-about for macOS
+      shell: bash
+      if: runner.os == 'macOS'
+      run: |
+        release_info="$(curl \
+          --silent \
+          --show-error \
+          --retry 5 \
+          --fail \
+          --header "Accept: application/vnd.github.v3+json" \
+          "https://api.github.com/repos/EmbarkStudios/cargo-about/releases"
+        )"
+        release_url="$(echo "$release_info" | jq -r '
+          .[0].assets
+          | map(select(.browser_download_url
+          | test(".*x86_64-apple-darwin.*tar.gz$")))
+          | .[0].browser_download_url
+          '
+        )"
+        curl --silent --show-error --retry 5 --fail --location "$release_url" | gtar xvz -C /usr/local/bin/ --strip-components=1
+
+    - name: Install cargo-about for Windows
+      shell: bash
+      if: runner.os == 'Windows'
+      run: |
+        release_info="$(curl \
+          --silent \
+          --show-error \
+          --retry 5 \
+          --fail \
+          --header "Accept: application/vnd.github.v3+json" \
+          "https://api.github.com/repos/EmbarkStudios/cargo-about/releases"
+        )"
+        release_url="$(echo "$release_info" | jq -r '
+          .[0].assets
+          | map(select(.browser_download_url
+          | test(".*x86_64-pc-windows-msvc.*tar.gz$")))
+          | .[0].browser_download_url
+          '
+        )"
+        archive='${{ github.workspace }}\cargo-about-bin\cargo-about.tar.gz'
+        extract_to='${{ github.workspace }}\cargo-about-bin'
+        mkdir "$extract_to"
+        curl --silent --show-error --retry 5 --fail --location "$release_url" > "$archive"
+        tar xvzf "$archive" -C "$extract_to" --strip-components=1
+        echo "$extract_to" >> $GITHUB_PATH
 
     - name: Generate THIRDPARTY
       shell: bash


### PR DESCRIPTION
Refactors the cargo-about install step to move conditionals to individual job steps.

This hopes to fix transient errors when processing release info with `jq` in the nightly builder.