### PR TITLE
Add development gem group, don't install them during GitHub Action

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,9 +2,9 @@
 
 source 'https://rubygems.org'
 
-gem 'bundler-audit', '~> 0.9', require: false
-gem 'rake', '>= 12.3.3', require: false
-gem 'rubocop', '~> 1.36', require: false
-gem 'rubocop-rake', '~> 0.6', require: false
+gem 'bundler-audit', '~> 0.9', require: false, group: :development
+gem 'rake', '>= 12.3.3', require: false, group: :development
+gem 'rubocop', '~> 1.36', require: false, group: :development
+gem 'rubocop-rake', '~> 0.6', require: false, group: :development
 
 gem 'generate_third_party', path: '.'

--- a/action.yaml
+++ b/action.yaml
@@ -25,8 +25,10 @@ runs:
 
     - name: Install Ruby toolchain
       uses: ruby/setup-ruby@v1
+      env:
+        BUNDLE_WITHOUT: development
       with:
-        ruby-version: ".ruby-version"
+        ruby-version: "3.1.2"
         bundler-cache: true
         working-directory: ${{ github.action_path }}
 
@@ -105,3 +107,5 @@ runs:
           "${{ inputs.target_triple }}" \
           "${{ github.workspace }}/artichoke-${{ inputs.artichoke_ref }}/Cargo.toml" \
           > "${{ inputs.output_file }}"
+      env:
+        BUNDLE_WITHOUT: development


### PR DESCRIPTION
Also set explicit ruby version and don't rely on a `.ruby-version` file being present.