### PR TITLE
Add a Ruby script for downloading cargo-about

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -38,8 +38,8 @@ runs:
       run: |
         release_info="$(curl \
           --silent \
-          --show-error \
           --retry 5 \
+          --retry-all-errors \
           --fail \
           --header "Accept: application/vnd.github.v3+json" \
           "https://api.github.com/repos/EmbarkStudios/cargo-about/releases"
@@ -51,7 +51,7 @@ runs:
           | .[0].browser_download_url
           '
         )"
-        curl --silent --show-error --retry 5 --fail --location "$release_url" | tar xvz -C /usr/local/bin/ --strip-components=1
+        curl --silent --retry 5 --retry-all-errors --fail --location "$release_url" | tar xvz -C /usr/local/bin/ --strip-components=1
 
     - name: Install cargo-about for macOS
       shell: bash
@@ -59,8 +59,8 @@ runs:
       run: |
         release_info="$(curl \
           --silent \
-          --show-error \
           --retry 5 \
+          --retry-all-errors \
           --fail \
           --header "Accept: application/vnd.github.v3+json" \
           "https://api.github.com/repos/EmbarkStudios/cargo-about/releases"
@@ -72,7 +72,7 @@ runs:
           | .[0].browser_download_url
           '
         )"
-        curl --silent --show-error --retry 5 --fail --location "$release_url" | gtar xvz -C /usr/local/bin/ --strip-components=1
+        curl --silent --retry 5 --retry-all-errors --fail --location "$release_url" | gtar xvz -C /usr/local/bin/ --strip-components=1
 
     - name: Install cargo-about for Windows
       shell: bash
@@ -80,8 +80,8 @@ runs:
       run: |
         release_info="$(curl \
           --silent \
-          --show-error \
           --retry 5 \
+          --retry-all-errors \
           --fail \
           --header "Accept: application/vnd.github.v3+json" \
           "https://api.github.com/repos/EmbarkStudios/cargo-about/releases"
@@ -94,7 +94,7 @@ runs:
           '
         )"
         mkdir '${{ github.workspace }}\cargo-about-bin'
-        curl --silent --show-error --retry 5 --fail --location "$release_url" > '${{ github.workspace }}\cargo-about-bin\cargo-about.tar.gz'
+        curl --silent --retry 5 --retry-all-errors --fail --location "$release_url" > '${{ github.workspace }}\cargo-about-bin\cargo-about.tar.gz'
         cd '${{ github.workspace }}\cargo-about-bin'
         tar xvzf 'cargo-about.tar.gz' -C '.' --strip-components=1
         echo '${{ github.workspace }}\cargo-about-bin' >> $GITHUB_PATH

--- a/action.yaml
+++ b/action.yaml
@@ -21,7 +21,7 @@ runs:
       with:
         repository: artichoke/artichoke
         ref: ${{ inputs.artichoke_ref }}
-        path: "artichoke-${{ inputs.artichoke_ref }}"
+        path: "generate-third-party-artichoke-${{ inputs.artichoke_ref }}"
 
     - name: Install Ruby toolchain
       uses: ruby/setup-ruby@v1
@@ -32,72 +32,12 @@ runs:
         bundler-cache: true
         working-directory: ${{ github.action_path }}
 
-    - name: Install cargo-about for Linux
+    - name: Install cargo-about
       shell: bash
-      if: runner.os == 'Linux'
-      run: |
-        release_info="$(curl \
-          --silent \
-          --retry 5 \
-          --retry-all-errors \
-          --fail \
-          --header "Accept: application/vnd.github.v3+json" \
-          "https://api.github.com/repos/EmbarkStudios/cargo-about/releases"
-        )"
-        release_url="$(echo "$release_info" | jq -r '
-          .[0].assets
-          | map(select(.browser_download_url
-          | test(".*x86_64-unknown-linux.*tar.gz$")))
-          | .[0].browser_download_url
-          '
-        )"
-        curl --silent --retry 5 --retry-all-errors --fail --location "$release_url" | tar xvz -C /usr/local/bin/ --strip-components=1
-
-    - name: Install cargo-about for macOS
-      shell: bash
-      if: runner.os == 'macOS'
-      run: |
-        release_info="$(curl \
-          --silent \
-          --retry 5 \
-          --retry-all-errors \
-          --fail \
-          --header "Accept: application/vnd.github.v3+json" \
-          "https://api.github.com/repos/EmbarkStudios/cargo-about/releases"
-        )"
-        release_url="$(echo "$release_info" | jq -r '
-          .[0].assets
-          | map(select(.browser_download_url
-          | test(".*x86_64-apple-darwin.*tar.gz$")))
-          | .[0].browser_download_url
-          '
-        )"
-        curl --silent --retry 5 --retry-all-errors --fail --location "$release_url" | gtar xvz -C /usr/local/bin/ --strip-components=1
-
-    - name: Install cargo-about for Windows
-      shell: bash
-      if: runner.os == 'Windows'
-      run: |
-        release_info="$(curl \
-          --silent \
-          --retry 5 \
-          --retry-all-errors \
-          --fail \
-          --header "Accept: application/vnd.github.v3+json" \
-          "https://api.github.com/repos/EmbarkStudios/cargo-about/releases"
-        )"
-        release_url="$(echo "$release_info" | jq -r '
-          .[0].assets
-          | map(select(.browser_download_url
-          | test(".*x86_64-pc-windows-msvc.*tar.gz$")))
-          | .[0].browser_download_url
-          '
-        )"
-        mkdir '${{ github.workspace }}\cargo-about-bin'
-        curl --silent --retry 5 --retry-all-errors --fail --location "$release_url" > '${{ github.workspace }}\cargo-about-bin\cargo-about.tar.gz'
-        cd '${{ github.workspace }}\cargo-about-bin'
-        tar xvzf 'cargo-about.tar.gz' -C '.' --strip-components=1
-        echo '${{ github.workspace }}\cargo-about-bin' >> $GITHUB_PATH
+      working-directory: ${{ github.action_path }}
+      run: bundle exec install-cargo-about "${{ runner.os }}"
+      env:
+        BUNDLE_WITHOUT: development
 
     - name: Generate THIRDPARTY
       shell: bash
@@ -105,7 +45,11 @@ runs:
       run: |
         bundle exec generate-third-party-text-file-single-target \
           "${{ inputs.target_triple }}" \
-          "${{ github.workspace }}/artichoke-${{ inputs.artichoke_ref }}/Cargo.toml" \
+          "${{ github.workspace }}/generate-third-party-artichoke-${{ inputs.artichoke_ref }}/Cargo.toml" \
           > "${{ inputs.output_file }}"
       env:
         BUNDLE_WITHOUT: development
+
+    - name: Cleanup
+      shell: bash
+      run: rm -rf "${{ github.workspace }}/generate-third-party-artichoke-${{ inputs.artichoke_ref }}"

--- a/bin/install-cargo-about
+++ b/bin/install-cargo-about
@@ -123,7 +123,10 @@ bin_path = log_group('Install cargo-about') do
 end
 
 if (path_file = ENV.fetch('GITHUB_PATH', nil))
-  File.open(path_file, 'a') do |f|
-    f.puts bin_path
+  log_group('Modifying path') do
+    File.open(path_file, 'a') do |f|
+      f.puts bin_path
+    end
+    puts "Entries added to path:\n\t#{bin_path}"
   end
 end

--- a/bin/install-cargo-about
+++ b/bin/install-cargo-about
@@ -1,0 +1,129 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# avoid ugly stacks on permissible signals
+Signal.trap('INT', 'SYSTEM_DEFAULT') if Signal.list.include?('INT')
+Signal.trap('PIPE', 'SYSTEM_DEFAULT') if Signal.list.include?('PIPE')
+
+require 'fileutils'
+require 'json'
+require 'open-uri'
+require 'rubygems/package'
+require 'securerandom'
+require 'stringio'
+require 'tmpdir'
+
+# Set an output for a GitHub Actions job.
+#
+# https://docs.github.com/en/actions/using-jobs/defining-outputs-for-jobs
+def set_output(name:, value:)
+  puts "::set-output name=#{name}::#{value}"
+end
+
+# Create an expandable log group in GitHub Actions job logs.
+#
+# https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#grouping-log-lines
+def log_group(group)
+  puts "::group::#{group}"
+  begin
+    yield
+  ensure
+    puts '::endgroup::'
+  end
+end
+
+# Retry a block the given number of times with rudimentary backoff.
+def retry_with(times:)
+  yield
+rescue StandardError => e
+  puts "Error during processing: #{e.class}: #{e}"
+  puts "Backtrace:\n\t#{e.backtrace.join("\n\t")}"
+
+  times -= 1
+  raise if times.zero?
+
+  puts 'Retrying ...'
+  sleep 5
+  retry
+end
+
+platform_filter =
+  case ARGV[0]&.downcase
+  when 'linux' then /.*x86_64-unknown-linux.*tar.gz$/
+  when 'macos' then /.*x86_64-apple-darwin.*tar.gz$/
+  when 'windows' then /.*x86_64-pc-windows-msvc.*tar.gz$/
+  when nil
+    warn("USAGE: #{$PROGRAM_NAME} [ linux | macos | windows ]")
+    exit 1
+  else
+    warn('Unsupported platform')
+    warn
+    warn("USAGE: #{$PROGRAM_NAME} [ linux | macos | windows ]")
+    exit 1
+  end
+
+artifact_url, artifact_name = log_group('Get current cargo-about release') do
+  releases_endpoint = URI.parse('https://api.github.com/repos/EmbarkStudios/cargo-about/releases')
+
+  retry_with(times: 5) do
+    releases_endpoint.open('Accept' => 'application/vnd.github.v3+json') do |data|
+      buf = StringIO.new
+      IO.copy_stream(data, buf)
+
+      metadata = JSON.parse(buf.string)
+
+      release = metadata.fetch(0)
+      puts "Found cargo-about #{release.fetch('tag_name')}"
+
+      assets = release.fetch('assets')
+      artifact = assets.find { |asset| platform_filter.match?(asset.fetch('browser_download_url')) }
+
+      name = artifact.fetch('name')
+      download_url = artifact.fetch('browser_download_url')
+
+      puts "cargo-about download URL: #{download_url}"
+
+      [download_url, name]
+    end
+  end
+end
+
+# Make temporary directory to install `cargo-about` binaries to.
+#
+# If running on GitHub Actions, use the `RUNNER_TEMP` directory.
+#
+# `RUNNER_TEMP` is the path to a temporary directory on the runner. This
+# directory is emptied at the beginning and end of each job.
+temp_dir = ENV.fetch('RUNNER_TEMP') do
+  Dir.mktmpdir(['generate_third_party', SecureRandom.hex])
+end
+destination = File.join(temp_dir, 'cargo-about-bin')
+FileUtils.mkdir_p(destination)
+
+bin_path = log_group('Install cargo-about') do
+  retry_with(times: 5) do
+    puts "Downloading cargo-about from #{artifact_url}"
+
+    URI.parse(artifact_url).open do |data|
+      puts 'Download in progress'
+      puts "Extracting tarball to #{destination}"
+
+      Gem::Package.new('').extract_tar_gz(data, destination)
+
+      puts 'Extraction complete'
+    end
+
+    bin_path = File.join(destination, artifact_name.delete_suffix('.tar.gz'))
+
+    puts "Installed cargo-about to #{destination}"
+    puts "Binary path: #{bin_path}"
+
+    bin_path
+  end
+end
+
+if (path_file = ENV.fetch('GITHUB_PATH', nil))
+  File.open(path_file, 'a') do |f|
+    f.puts bin_path
+  end
+end

--- a/generate_third_party.gemspec
+++ b/generate_third_party.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |s|
   s.executables << 'generate-third-party-html'
   s.executables << 'generate-third-party-text-file'
   s.executables << 'generate-third-party-text-file-single-target'
+  s.executables << 'install-cargo-about'
   s.metadata = {
     'rubygems_mfa_required' => 'true'
   }


### PR DESCRIPTION
Fixes some flakes in CI and the nightly builder where curl fails to
fetch release metadata from GitHub with:

```
curl: (22) The requested URL returned error: 403
```

Add Ruby script for downloading cargo-about

Downloading release information with curl and piping it to jq is flaky
in CI and in the nightly builder, sometimes resulting in 403 errors that
curl treats as unrecoverable.

curl has a `--retry-all-errors` flag but it is unavailable on Windows or
Ubuntu 20.04.

Add a small Ruby script using only the standard library that is
installed as part of the `generate_third_party` gem. This script
features retries on network errors, logging with log GitHub Actions log
groups, and automatically adds the resulting cargo-about binaries to
$PATH.

The script takes a platform as its first argument which conveniently
matches the `runner.os` context variable in a GitHub Actions context.