### PR TITLE
Pass a GITHUB_TOKEN to the cargo-about installer script

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,6 +41,7 @@ jobs:
           artichoke_ref: trunk
           target_triple: ${{ matrix.target }}
           output_file: THIRDPARTY
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check THIRDPARTY output
         shell: bash
@@ -82,6 +83,7 @@ jobs:
           artichoke_ref: trunk
           target_triple: ${{ matrix.target }}
           output_file: THIRDPARTY
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check THIRDPARTY output
         shell: bash

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ This repository is available as a GitHub Action:
     artichoke_ref: trunk
     target_triple: x86_64-unknown-linux-gnu
     output_file: ${{ github.workspace }}/THIRDPARTY
+    github_token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
 ## Supported Targets

--- a/action.yaml
+++ b/action.yaml
@@ -12,6 +12,9 @@ inputs:
   output_file:
     required: true
     type: string
+  github_token:
+    required: true
+    type: string
 
 runs:
   using: "composite"
@@ -38,6 +41,7 @@ runs:
       run: bundle exec install-cargo-about "${{ runner.os }}"
       env:
         BUNDLE_WITHOUT: development
+        GITHUB_TOKEN: ${{ inputs.github_token }}
 
     - name: Generate THIRDPARTY
       shell: bash

--- a/bin/install-cargo-about
+++ b/bin/install-cargo-about
@@ -65,8 +65,13 @@ platform_filter =
 artifact_url, artifact_name = log_group('Get current cargo-about release') do
   releases_endpoint = URI.parse('https://api.github.com/repos/EmbarkStudios/cargo-about/releases')
 
+  headers = { 'Accept' => 'application/json' }
+  if (github_token = ENV.fetch('GITHUB_TOKEN', nil))
+    headers['Authorization'] = "Bearer #{github_token}"
+  end
+
   retry_with(times: 5) do
-    releases_endpoint.open('Accept' => 'application/vnd.github.v3+json') do |data|
+    releases_endpoint.open(headers) do |data|
       buf = StringIO.new
       IO.copy_stream(data, buf)
 


### PR DESCRIPTION
Use a GitHub PAT if it is available in the environment to authenticate to the cargo-about releases API.

This hopefully should work around the 403 rate-limiting errors when running this task in the nightly builder.

Fixes #16.