### PR TITLE
Migrate thirdparty listing binaries to scripts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,6 +50,40 @@ jobs:
             exit 1
           fi
 
+  test-all-targets:
+    name: Test (all targets)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Clone Artichoke
+        uses: actions/checkout@v3
+        with:
+          repository: artichoke/artichoke
+          path: "artichoke"
+
+      - name: Install Ruby toolchain
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "2.7.6"
+          bundler-cache: true
+
+      - name: Install cargo-about
+        run: bundle exec install-cargo-about "${{ runner.os }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate THIRDPARTY for all targets
+        run: bundle exec generate-third-party-text-file artichoke/Cargo.toml
+
+      - name: Check THIRDPARTY output
+        shell: bash
+        run: |
+          if (( $(grep -c . < THIRDPARTY) < 10 )); then
+            exit 1
+          fi
+
   platform-support:
     name: Platform Support
     runs-on: ${{ matrix.os }}

--- a/action.yaml
+++ b/action.yaml
@@ -47,7 +47,7 @@ runs:
       shell: bash
       run: |
         generate-third-party-text-file-single-target \
-          "${{ inputs.target_triple }}" \
+          --target "${{ inputs.target_triple }}" \
           "${{ github.workspace }}/generate-third-party-artichoke-${{ inputs.artichoke_ref }}/Cargo.toml" \
           > "${{ inputs.output_file }}"
 

--- a/bin/generate-third-party-text-file
+++ b/bin/generate-third-party-text-file
@@ -2,28 +2,7 @@
 # typed: strict
 # frozen_string_literal: true
 
-# avoid ugly stacks on permissible signals
-Signal.trap('INT', 'SYSTEM_DEFAULT') if Signal.list.include?('INT')
-Signal.trap('PIPE', 'SYSTEM_DEFAULT') if Signal.list.include?('PIPE')
-
 require 'generate_third_party'
+require 'generate_third_party/script/generate_third_party_text_file'
 
-manifest_path = ARGV[0]
-if manifest_path.nil? || !manifest_path.end_with?('Cargo.toml')
-  warn 'Error: Must pass path to `Cargo.toml` as first argument.'
-  exit 1
-end
-
-unless Artichoke::GenerateThirdParty::CargoAbout.present?
-  warn <<~ERR
-    Error: `cargo-about` not found in PATH.
-
-    Try installing `cargo-about` with:
-
-        cargo install cargo-about
-
-  ERR
-  exit 1
-end
-
-puts Artichoke::GenerateThirdParty::Command::ExtractLicensesForAllTargets.call(manifest_path)
+Artichoke::GenerateThirdParty::Script::GenerateThirdPartyTextFile.main

--- a/bin/generate-third-party-text-file-single-target
+++ b/bin/generate-third-party-text-file-single-target
@@ -2,57 +2,7 @@
 # typed: strict
 # frozen_string_literal: true
 
-# avoid ugly stacks on permissible signals
-Signal.trap('INT', 'SYSTEM_DEFAULT') if Signal.list.include?('INT')
-Signal.trap('PIPE', 'SYSTEM_DEFAULT') if Signal.list.include?('PIPE')
-
 require 'generate_third_party'
+require 'generate_third_party/script/generate_third_party_text_file_for_target'
 
-triple = T.let(ARGV[0], T.nilable(String))
-
-if triple.nil?
-  warn <<~ERR
-    Error: Missing required TARGET argument.
-
-    Usage: generate-third-party-text-file-single-target TARGET manifest-path
-
-    Where TARGET is one of:
-
-    #{Artichoke::GenerateThirdParty::Target.values.map { |target| "- #{target.serialize}" }.join("\n").strip}
-  ERR
-  exit 2
-end
-
-manifest_path = T.let(ARGV[1], T.nilable(String))
-if manifest_path.nil? || !manifest_path.end_with?('Cargo.toml')
-  warn 'Error: Must pass path to `Cargo.toml` as positional argument.'
-  exit 1
-end
-
-parsed_target = Artichoke::GenerateThirdParty::Target.try_deserialize(triple)
-if parsed_target.nil?
-  warn <<~ERR
-    Error: Unknown TARGET.
-
-    Usage: generate-third-party-text-file-single-target TARGET
-
-    Where TARGET is one of:
-
-    #{Artichoke::GenerateThirdParty::Target.values.map { |target| "- #{target.serialize}" }.join("\n").strip}
-  ERR
-  exit 2
-end
-
-unless Artichoke::GenerateThirdParty::CargoAbout.present?
-  warn <<~ERR
-    Error: `cargo-about` not found in PATH.
-
-    Try installing `cargo-about` with:
-
-        cargo install cargo-about
-
-  ERR
-  exit 1
-end
-
-puts Artichoke::GenerateThirdParty::Command::ExtractLicensesForSingleTarget.call(parsed_target, manifest_path)
+Artichoke::GenerateThirdParty::Script::GenerateThirdPartyTextFileForTarget.main

--- a/lib/generate_third_party.rb
+++ b/lib/generate_third_party.rb
@@ -3,6 +3,7 @@
 
 require 'sorbet-runtime'
 
+require_relative 'generate_third_party/bin_tools'
 require_relative 'generate_third_party/cargo_about'
 require_relative 'generate_third_party/deps'
 require_relative 'generate_third_party/target'

--- a/lib/generate_third_party/bin_tools.rb
+++ b/lib/generate_third_party/bin_tools.rb
@@ -1,0 +1,19 @@
+# typed: strict
+# frozen_string_literal: true
+
+require 'sorbet-runtime'
+
+module Artichoke
+  module GenerateThirdParty
+    module BinTools
+      extend T::Sig
+
+      sig { void }
+      def self.setup_script_signal_handlers!
+        # avoid ugly stacks on permissible signals
+        Signal.trap('INT', 'SYSTEM_DEFAULT') if Signal.list.include?('INT')
+        Signal.trap('PIPE', 'SYSTEM_DEFAULT') if Signal.list.include?('PIPE')
+      end
+    end
+  end
+end

--- a/lib/generate_third_party/cargo_about.rb
+++ b/lib/generate_third_party/cargo_about.rb
@@ -16,6 +16,20 @@ module Artichoke
         status.success? || false
       end
 
+      sig { void }
+      def self.assert_on_path!
+        return if present?
+
+        warn <<~ERR
+          Error: `cargo-about` not found in PATH.
+
+          Try installing `cargo-about` with:
+
+          $ install-cargo-about
+        ERR
+        exit(1)
+      end
+
       sig { params(config: String, manifest_path: String, template: T.nilable(String)).void }
       def initialize(config:, manifest_path:, template: nil)
         template = File.join(__dir__, 'cargo_about', 'about.hbs') if template.nil?

--- a/lib/generate_third_party/script/generate_third_party_text_file.rb
+++ b/lib/generate_third_party/script/generate_third_party_text_file.rb
@@ -1,0 +1,58 @@
+# typed: strict
+# frozen_string_literal: true
+
+require 'optparse'
+require 'sorbet-runtime'
+
+module Artichoke
+  module GenerateThirdParty
+    module Script
+      class GenerateThirdPartyTextFile
+        extend T::Sig
+
+        class Arguments < T::Struct
+          extend T::Sig
+
+          const :manifest_path, String
+
+          sig { returns(Arguments) }
+          def self.from_argv!
+            option_parser = OptionParser.new do |opts|
+              opts.banner = 'Usage: generate-third-party-text-file path/to/Cargo.toml'
+            end
+
+            begin
+              option_parser.parse!
+            rescue OptionParser::InvalidOption => e
+              warn option_parser.to_s
+              warn ''
+              warn e.to_s
+              exit(2)
+            end
+
+            manifest_path, *rest = ARGV
+            if manifest_path.nil? || rest.nil? || !rest.empty? || !manifest_path.end_with?('Cargo.toml')
+              warn option_parser.to_s
+              exit(2)
+            end
+
+            new(manifest_path: manifest_path)
+          end
+        end
+
+        private_class_method :new
+
+        sig { void }
+        def self.main
+          BinTools.setup_script_signal_handlers!
+
+          args = Arguments.from_argv!
+          CargoAbout.assert_on_path!
+
+          license_listing = Command::ExtractLicensesForAllTargets.call(args.manifest_path)
+          puts license_listing
+        end
+      end
+    end
+  end
+end

--- a/lib/generate_third_party/script/generate_third_party_text_file_for_target.rb
+++ b/lib/generate_third_party/script/generate_third_party_text_file_for_target.rb
@@ -1,0 +1,65 @@
+# typed: strict
+# frozen_string_literal: true
+
+require 'optparse'
+require 'sorbet-runtime'
+
+module Artichoke
+  module GenerateThirdParty
+    module Script
+      class GenerateThirdPartyTextFileForTarget
+        extend T::Sig
+
+        class Arguments < T::Struct
+          extend T::Sig
+
+          const :manifest_path, String
+          const :target, Target
+
+          sig { returns(Arguments) }
+          def self.from_argv!
+            target = T.let(nil, T.nilable(Target))
+
+            option_parser = OptionParser.new do |opts|
+              opts.banner = 'Usage: generate-third-party-text-file path/to/Cargo.toml'
+
+              opts.on('-t', '--target TARGET', 'Target platform triple') do |arg|
+                target = Target.try_deserialize(arg)
+              end
+            end
+
+            begin
+              option_parser.parse!
+            rescue OptionParser::InvalidOption => e
+              warn option_parser.to_s
+              warn ''
+              warn e.to_s
+              exit(2)
+            end
+
+            manifest_path, *rest = ARGV
+            if manifest_path.nil? || rest.nil? || !rest.empty? || !manifest_path.end_with?('Cargo.toml') || target.nil?
+              warn option_parser.to_s
+              exit(2)
+            end
+
+            new(manifest_path: manifest_path, target: target)
+          end
+        end
+
+        private_class_method :new
+
+        sig { void }
+        def self.main
+          BinTools.setup_script_signal_handlers!
+
+          args = Arguments.from_argv!
+          CargoAbout.assert_on_path!
+
+          license_listing = Command::ExtractLicensesForSingleTarget.call(args.target, args.manifest_path)
+          puts license_listing
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
binstubs are thin wrappers over the scripts which live in lib.