### PR TITLE
Fix cargo-about Artichoke license checksum errors on Windows

### DIFF
--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -25,7 +25,7 @@
   description: "Area: Security vulnerabilities and unsoundness issues."
 - name: "A-target"
   color: "f7e101"
-  description: "Area: nightly build support for various target triples."
+  description: "Area: build support for various target triples."
 - name: "A-thirdparty"
   color: "f7e101"
   description: "Area: THIRDPARTY license listings."

--- a/action.yaml
+++ b/action.yaml
@@ -19,6 +19,13 @@ inputs:
 runs:
   using: "composite"
   steps:
+    # https://github.com/actions/checkout/issues/135
+    - name: Setup git line ending checkout behavior
+      shell: bash
+      run: |
+        git config --system core.autocrlf false
+        git config --system core.eol lf
+
     - name: Clone Artichoke
       uses: actions/checkout@v3
       with:

--- a/action.yaml
+++ b/action.yaml
@@ -22,6 +22,7 @@ runs:
     # https://github.com/actions/checkout/issues/135
     - name: Setup git line ending checkout behavior
       shell: bash
+      if: runner.os == 'Windows'
       run: |
         git config --system core.autocrlf false
         git config --system core.eol lf


### PR DESCRIPTION
On Windows, GitHub Actions's native checkout action `@actions/checkout` does Windows CRLF normalization. This breaks the SHA256 checksum of the license files used in `clarify` sections in cargo-about config files embedded in this repository, leading to warnings like this in CI:

```
2022-10-01 17:18:11.8629067 +00:00:00 [WARN] failed to validate all files specified in clarification for crate artichoke 0.1.0-pre.0: checksum mismatch, expected a7f7d7c7ab9585b1c5e43d592c648d6d3fff7debcf7cfbde301f63b02157444d
2022-10-01 17:18:11.8632725 +00:00:00 [WARN] failed to validate all files specified in clarification for crate artichoke-backend 0.19.0: checksum mismatch, expected a7f7d7c7ab9585b1c5e43d592c648d6d3fff7debcf7cfbde301f63b02157444d
```

This commit adds an additional step to the composite action to ensure git is configured with LF EOL behavior and does not normalize using autocrlf

See:

- https://github.com/actions/checkout/issues/135