### PR TITLE
Address deprecated 'set-output' command in GitHub Actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 1.3.0
+
+Released 2022-10-31.
+
+### Bug Fixes
+
+- Address deprecated 'set-output' command in GitHub Actions. [#38]
+
+[#38]: https://github.com/artichoke/generate_third_party/pull/38
+
 ## 1.2.0
 
 Released 2022-10-15.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    generate_third_party (1.2.0)
+    generate_third_party (1.3.0)
       sorbet-runtime (~> 0.5)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This repository is available as a GitHub Action:
 ```yaml
 - name: Generate THIRDPARTY license listing
   id: generate_third_party
-  uses: artichoke/generate_third_party@v1.2.0
+  uses: artichoke/generate_third_party@v1.3.0
   with:
     artichoke_ref: trunk
     target_triple: x86_64-unknown-linux-gnu

--- a/action.yaml
+++ b/action.yaml
@@ -39,9 +39,9 @@ runs:
       run: |
         gem build generate_third_party.gemspec
         if [[ "${{ runner.os }}" == "Linux" ]]; then
-          sudo gem install generate_third_party-1.2.0.gem
+          sudo gem install generate_third_party-1.3.0.gem
         else
-          gem install generate_third_party-1.2.0.gem
+          gem install generate_third_party-1.3.0.gem
         fi
       working-directory: ${{ github.action_path }}
 

--- a/generate_third_party.gemspec
+++ b/generate_third_party.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name                  = 'generate_third_party'
-  s.version               = '1.2.0'
+  s.version               = '1.3.0'
   s.required_ruby_version = '>= 2.7.0'
   s.summary               = "Generate Artichoke's third party dependencies"
   s.description           = 'Generate lists of third party dependencies and their licenses'

--- a/lib/generate_third_party/bin_tools.rb
+++ b/lib/generate_third_party/bin_tools.rb
@@ -23,7 +23,12 @@ module Artichoke
       # https://docs.github.com/en/actions/using-jobs/defining-outputs-for-jobs
       sig { params(name: String, value: String).void }
       def self.set_output(name:, value:)
-        puts "::set-output name=#{name}::#{value}"
+        out = ENV.fetch('GITHUB_OUTPUT', nil)
+        return if out.nil?
+
+        File.open(out, 'a') do |f|
+          f.puts "#{name}=#{value}"
+        end
       end
 
       # Create an expandable log group in GitHub Actions job logs.


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

This change follows the same pattern as the Python changes in https://github.com/artichoke/nightly/pull/111.