### PR TITLE
Permit ISC and BSD-3-Clause license types

### DIFF
--- a/lib/generate_third_party/cargo_about/about.hbs
+++ b/lib/generate_third_party/cargo_about/about.hbs
@@ -5,8 +5,10 @@ deps:
   - name: "{{{crate.name}}}"
     version: "{{{crate.version}}}"
     url: "{{#if crate.repository ~}} {{{crate.repository}}} {{~ else ~}} https://crates.io/crates/{{{crate.name}}} {{~ /if}}"
-    license: "{{{../name}}}"
-    license_id: "{{{../id}}}"
+    license: >-
+      {{{../name}}}
+    license_id: >-
+      {{{../id}}}
 @@@@text-start@@@@
 {{{../text}}}
 @@@@text-end@@@@
@@ -15,8 +17,10 @@ deps:
   - name: "mruby"
     version: "3.1.0"
     url: "https://github.com/mruby/mruby"
-    license: "MIT License"
-    license_id: "MIT"
+    license: >-
+      MIT License
+    license_id: >-
+      MIT
     text: |
       Copyright (c) 2010-2021 mruby developers
 
@@ -40,8 +44,10 @@ deps:
   - name: "oniguruma"
     version: "6.9.8"
     url: "https://github.com/kkos/oniguruma/tree/08d36110c5670c815ad6d6f969e578049d209080"
-    license: "2-Clause BSD License"
-    license_id: "BSD-2-Clause"
+    license: >-
+      2-Clause BSD License
+    license_id: >-
+      BSD-2-Clause
     text: |
       Oniguruma LICENSE
       -----------------

--- a/lib/generate_third_party/deps.rb
+++ b/lib/generate_third_party/deps.rb
@@ -32,8 +32,10 @@ module Artichoke
           - name: #{name}
             version: "#{version}"
             url: "#{url}"
-            license: #{license}
-            license_id: #{license_id}
+            license: >-
+              #{license}
+            license_id: >-
+              #{license_id}
         YAML
 
         # The `|2` indentation specifier is necessary because some licenses like

--- a/lib/generate_third_party/targets/aarch64-apple-darwin.toml
+++ b/lib/generate_third_party/targets/aarch64-apple-darwin.toml
@@ -2,7 +2,9 @@ accepted = [
   "MIT",
   "Apache-2.0",
   "Apache-2.0 WITH LLVM-exception",
+  "BSD-3-Clause",
   "BSL-1.0",
+  "ISC",
   "Unicode-DFS-2016",
 ]
 targets = [

--- a/lib/generate_third_party/targets/aarch64-unknown-linux-gnu.toml
+++ b/lib/generate_third_party/targets/aarch64-unknown-linux-gnu.toml
@@ -2,7 +2,9 @@ accepted = [
   "MIT",
   "Apache-2.0",
   "Apache-2.0 WITH LLVM-exception",
+  "BSD-3-Clause",
   "BSL-1.0",
+  "ISC",
   "Unicode-DFS-2016",
 ]
 targets = [

--- a/lib/generate_third_party/targets/aarch64-unknown-linux-musl.toml
+++ b/lib/generate_third_party/targets/aarch64-unknown-linux-musl.toml
@@ -2,7 +2,9 @@ accepted = [
   "MIT",
   "Apache-2.0",
   "Apache-2.0 WITH LLVM-exception",
+  "BSD-3-Clause",
   "BSL-1.0",
+  "ISC",
   "Unicode-DFS-2016",
 ]
 targets = [

--- a/lib/generate_third_party/targets/all.toml
+++ b/lib/generate_third_party/targets/all.toml
@@ -2,7 +2,9 @@ accepted = [
   "MIT",
   "Apache-2.0",
   "Apache-2.0 WITH LLVM-exception",
+  "BSD-3-Clause",
   "BSL-1.0",
+  "ISC",
   "Unicode-DFS-2016",
 ]
 targets = [

--- a/lib/generate_third_party/targets/i686-pc-windows-gnu.toml
+++ b/lib/generate_third_party/targets/i686-pc-windows-gnu.toml
@@ -2,7 +2,9 @@ accepted = [
   "MIT",
   "Apache-2.0",
   "Apache-2.0 WITH LLVM-exception",
+  "BSD-3-Clause",
   "BSL-1.0",
+  "ISC",
   "Unicode-DFS-2016",
 ]
 targets = [

--- a/lib/generate_third_party/targets/i686-pc-windows-msvc.toml
+++ b/lib/generate_third_party/targets/i686-pc-windows-msvc.toml
@@ -2,7 +2,9 @@ accepted = [
   "MIT",
   "Apache-2.0",
   "Apache-2.0 WITH LLVM-exception",
+  "BSD-3-Clause",
   "BSL-1.0",
+  "ISC",
   "Unicode-DFS-2016",
 ]
 targets = [

--- a/lib/generate_third_party/targets/i686-unknown-linux-gnu.toml
+++ b/lib/generate_third_party/targets/i686-unknown-linux-gnu.toml
@@ -2,7 +2,9 @@ accepted = [
   "MIT",
   "Apache-2.0",
   "Apache-2.0 WITH LLVM-exception",
+  "BSD-3-Clause",
   "BSL-1.0",
+  "ISC",
   "Unicode-DFS-2016",
 ]
 targets = [

--- a/lib/generate_third_party/targets/x86_64-apple-darwin.toml
+++ b/lib/generate_third_party/targets/x86_64-apple-darwin.toml
@@ -2,7 +2,9 @@ accepted = [
   "MIT",
   "Apache-2.0",
   "Apache-2.0 WITH LLVM-exception",
+  "BSD-3-Clause",
   "BSL-1.0",
+  "ISC",
   "Unicode-DFS-2016",
 ]
 targets = [

--- a/lib/generate_third_party/targets/x86_64-pc-windows-gnu.toml
+++ b/lib/generate_third_party/targets/x86_64-pc-windows-gnu.toml
@@ -2,7 +2,9 @@ accepted = [
   "MIT",
   "Apache-2.0",
   "Apache-2.0 WITH LLVM-exception",
+  "BSD-3-Clause",
   "BSL-1.0",
+  "ISC",
   "Unicode-DFS-2016",
 ]
 targets = [

--- a/lib/generate_third_party/targets/x86_64-pc-windows-msvc.toml
+++ b/lib/generate_third_party/targets/x86_64-pc-windows-msvc.toml
@@ -2,7 +2,9 @@ accepted = [
   "MIT",
   "Apache-2.0",
   "Apache-2.0 WITH LLVM-exception",
+  "BSD-3-Clause",
   "BSL-1.0",
+  "ISC",
   "Unicode-DFS-2016",
 ]
 targets = [

--- a/lib/generate_third_party/targets/x86_64-unknown-linux-gnu.toml
+++ b/lib/generate_third_party/targets/x86_64-unknown-linux-gnu.toml
@@ -2,7 +2,9 @@ accepted = [
   "MIT",
   "Apache-2.0",
   "Apache-2.0 WITH LLVM-exception",
+  "BSD-3-Clause",
   "BSL-1.0",
+  "ISC",
   "Unicode-DFS-2016",
 ]
 targets = [

--- a/lib/generate_third_party/targets/x86_64-unknown-linux-musl.toml
+++ b/lib/generate_third_party/targets/x86_64-unknown-linux-musl.toml
@@ -2,7 +2,9 @@ accepted = [
   "MIT",
   "Apache-2.0",
   "Apache-2.0 WITH LLVM-exception",
+  "BSD-3-Clause",
   "BSL-1.0",
+  "ISC",
   "Unicode-DFS-2016",
 ]
 targets = [


### PR DESCRIPTION
These licenses are used by bindgen and its dependencies. They are already permitted in upstream artichoke.

See:

- https://github.com/artichoke/artichoke/pull/2515
- https://github.com/artichoke/artichoke/commit/4b13ecec66f368f95559d057e34ba35e3fae9870

This change will fix build failures in nightly runners (and this repository once the weekly CI job kicks off).