### PR TITLE
Update embedded mruby license text to v3.2.0

### DIFF
--- a/lib/generate_third_party/cargo_about/about.hbs
+++ b/lib/generate_third_party/cargo_about/about.hbs
@@ -15,14 +15,14 @@ deps:
 {{/each}}
 {{/each}}
   - name: "mruby"
-    version: "3.1.0"
+    version: "3.2.0"
     url: "https://github.com/mruby/mruby"
     license: >-
       MIT License
     license_id: >-
       MIT
     text: |
-      Copyright (c) 2010-2021 mruby developers
+      Copyright (c) 2010-2023 mruby developers
 
       Permission is hereby granted, free of charge, to any person obtaining a
       copy of this software and associated documentation files (the "Software"),


### PR DESCRIPTION
See:

- https://mruby.org/releases/2023/02/24/mruby-3.2.0-released.html
- https://github.com/artichoke/artichoke/pull/2363