### PR TITLE
Upgrade gemspec minimum Ruby version to 3.0.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,7 @@ require:
   - rubocop-sorbet
 AllCops:
   NewCops: enable
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.0
   DisplayCopNames: true
   Exclude:
     - "**/node_modules/**/*"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    generate_third_party (1.7.0)
+    generate_third_party (1.8.0)
       sorbet-runtime (~> 0.5)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This repository is available as a GitHub Action:
 ```yaml
 - name: Generate THIRDPARTY license listing
   id: generate_third_party
-  uses: artichoke/generate_third_party@v1.7.0
+  uses: artichoke/generate_third_party@v1.8.0
   with:
     artichoke_ref: trunk
     target_triple: x86_64-unknown-linux-gnu

--- a/action.yaml
+++ b/action.yaml
@@ -39,9 +39,9 @@ runs:
       run: |
         gem build generate_third_party.gemspec
         if [[ "${{ runner.os }}" == "Linux" ]]; then
-          sudo gem install generate_third_party-1.7.0.gem
+          sudo gem install generate_third_party-1.8.0.gem
         else
-          gem install generate_third_party-1.7.0.gem
+          gem install generate_third_party-1.8.0.gem
         fi
       working-directory: ${{ github.action_path }}
 

--- a/generate_third_party.gemspec
+++ b/generate_third_party.gemspec
@@ -2,8 +2,8 @@
 
 Gem::Specification.new do |s|
   s.name                  = 'generate_third_party'
-  s.version               = '1.7.0'
-  s.required_ruby_version = '>= 2.7.0'
+  s.version               = '1.8.0'
+  s.required_ruby_version = '>= 3.0.0'
   s.summary               = "Generate Artichoke's third party dependencies"
   s.description           = 'Generate lists of third party dependencies and their licenses'
   s.authors               = ['Ryan Lopopolo']


### PR DESCRIPTION
The Ruby 2.7 release line is EOL as of the March 30, 2023 release of Ruby 2.7.8.

https://www.ruby-lang.org/en/news/2023/03/30/ruby-2-7-8-released/

Prepare a release of a new version, v1.8.0.