### PR TITLE
Checkout artichoke/artichoke repository in the a better temp directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 1.10.0
+
+Released 2023-04-27.
+
+### Action Changes
+
+- Checkout artichoke/artichoke repository in the a better temp directory. [#93]
+
+[#93]: https://github.com/artichoke/generate_third_party/pull/93
+
 ## 1.9.0
 
 Released 2023-04-27.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    generate_third_party (1.9.0)
+    generate_third_party (1.10.0)
       sorbet-runtime (~> 0.5)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This repository is available as a GitHub Action:
 ```yaml
 - name: Generate THIRDPARTY license listing
   id: generate_third_party
-  uses: artichoke/generate_third_party@v1.9.0
+  uses: artichoke/generate_third_party@v1.10.0
   with:
     artichoke_ref: trunk
     target_triple: x86_64-unknown-linux-gnu

--- a/action.yaml
+++ b/action.yaml
@@ -31,21 +31,34 @@ runs:
         git config --system core.autocrlf false
         git config --system core.eol lf
 
+    # `actions/checkout` only permits checkouts within the `github.workspace`
+    # directory. See https://github.com/actions/checkout/issues/197.
+    - name: Set paths
+      shell: bash
+      id: paths
+      run: |
+        temp_prefix="${{ github.workspace }}/${{ github.action }}-${{ github.run_id }}-${{ github.run_attempt }}"
+        mkdir -p "$temp_prefix"
+        artichoke_repository_path="${temp_prefix}/artichoke@${{ inputs.artichoke_ref }}"
+        echo "CLEANUP_PATH=${temp_prefix}" >> "$GITHUB_OUTPUT"
+        echo "ARTICHOKE_REPOSITORY_PATH=${artichoke_repository_path}" >> "$GITHUB_OUTPUT"
+        echo "CARGO_MANIFEST_PATH=${artichoke_repository_path}/Cargo.toml" >> "$GITHUB_OUTPUT"
+
     - name: Clone Artichoke
       uses: actions/checkout@v3
       with:
         repository: artichoke/artichoke
         ref: ${{ inputs.artichoke_ref }}
-        path: "generate-third-party-artichoke-${{ inputs.artichoke_ref }}"
+        path: ${{ steps.paths.outputs.ARTICHOKE_REPOSITORY_PATH }}
 
     - name: Install generate_third_party
       shell: bash
       run: |
         gem build generate_third_party.gemspec
         if [[ "${{ runner.os }}" == "Linux" ]]; then
-          sudo gem install generate_third_party-1.9.0.gem
+          sudo gem install generate_third_party-1.10.0.gem
         else
-          gem install generate_third_party-1.9.0.gem
+          gem install generate_third_party-1.10.0.gem
         fi
       working-directory: ${{ github.action_path }}
 
@@ -68,11 +81,11 @@ runs:
       run: |
         generate-third-party-text-file-single-target \
           --target "${{ inputs.target_triple }}" \
-          "${{ github.workspace }}/generate-third-party-artichoke-${{ inputs.artichoke_ref }}/Cargo.toml" \
+          "${{ steps.paths.outputs.CARGO_MANIFEST_PATH }}" \
           > "${{ inputs.output_file }}"
       env:
         RUST_TOOLCHAIN: stable
 
     - name: Cleanup
       shell: bash
-      run: rm -rf "${{ github.workspace }}/generate-third-party-artichoke-${{ inputs.artichoke_ref }}"
+      run: rm -rf "${{ steps.paths.outputs.CLEANUP_PATH }}"

--- a/generate_third_party.gemspec
+++ b/generate_third_party.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name                  = 'generate_third_party'
-  s.version               = '1.9.0'
+  s.version               = '1.10.0'
   s.required_ruby_version = '>= 3.0.0'
   s.summary               = "Generate Artichoke's third party dependencies"
   s.description           = 'Generate lists of third party dependencies and their licenses'


### PR DESCRIPTION
Set all relevant paths this GitHub Action uses in a single step:

- artichoke repository checkout path.
- Cargo.toml manifest path.
- cleanup path.

Prepare for v1.10.0 release.