### PR TITLE
Remove unneeded ignore pattern from markdown link check config

### DIFF
--- a/.github/markdown-link-check.json
+++ b/.github/markdown-link-check.json
@@ -4,9 +4,6 @@
       "pattern": "img.shields.io"
     },
     {
-      "pattern": "^https://docs.rs/.*"
-    },
-    {
       "pattern": "^https://twitter.com/artichokeruby"
     }
   ],


### PR DESCRIPTION
I'm not sure why all docs.rs links were ignored. There are none in this repo anyway.